### PR TITLE
Handle filesystem loads for gateway pages

### DIFF
--- a/services/gateway/public/index.html
+++ b/services/gateway/public/index.html
@@ -9,16 +9,23 @@
   <p id="info"></p>
   <ul id="users"></ul>
   <script>
+    // Determine the base URL to use for API calls and navigation. When the
+    // page is opened from the filesystem the origin starts with `file:` and
+    // we need to explicitly target the running gateway service.
+    const BASE_URL = window.location.origin.startsWith('file:')
+      ? 'http://localhost:3000'
+      : '';
+
     async function loadUsers() {
       const start = performance.now();
-      const res = await fetch('/users');
+      const res = await fetch(`${BASE_URL}/users`);
       const { data, time } = await res.json();
       document.getElementById('info').textContent = `Fetched in ${time}ms (client ${Math.round(performance.now() - start)}ms)`;
       const list = document.getElementById('users');
       data.forEach(u => {
         const li = document.createElement('li');
         const a = document.createElement('a');
-        a.href = `user.html?id=${u.id}`;
+        a.href = `${BASE_URL}/user.html?id=${u.id}`;
         a.textContent = u.name;
         li.appendChild(a);
         list.appendChild(li);

--- a/services/gateway/public/user.html
+++ b/services/gateway/public/user.html
@@ -16,27 +16,33 @@
     const params = new URLSearchParams(window.location.search);
     const userId = params.get('id');
     document.getElementById('title').textContent = `User ${userId}`;
-    async function load() {
-      const prodStart = performance.now();
-      const prodRes = await fetch('/products');
-      const prod = await prodRes.json();
-      document.getElementById('productsInfo').textContent = `Fetched in ${prod.time}ms (client ${Math.round(performance.now() - prodStart)}ms)`;
-      prod.data.forEach(p => {
-        const li = document.createElement('li');
-        li.textContent = p.name;
-        document.getElementById('products').appendChild(li);
-      });
-      const taskStart = performance.now();
-      const taskRes = await fetch('/tasks');
-      const task = await taskRes.json();
-      document.getElementById('tasksInfo').textContent = `Fetched in ${task.time}ms (client ${Math.round(performance.now() - taskStart)}ms)`;
-      task.data.filter(t => t.assigned_to === userId).forEach(t => {
-        const li = document.createElement('li');
-        li.textContent = t.title;
-        document.getElementById('tasks').appendChild(li);
-      });
-    }
-    load();
-  </script>
-</body>
+      // Determine the base URL so that API calls succeed even if this file is
+      // opened directly from disk (origin will start with `file:`).
+      const BASE_URL = window.location.origin.startsWith('file:')
+        ? 'http://localhost:3000'
+        : '';
+
+      async function load() {
+        const prodStart = performance.now();
+        const prodRes = await fetch(`${BASE_URL}/products`);
+        const prod = await prodRes.json();
+        document.getElementById('productsInfo').textContent = `Fetched in ${prod.time}ms (client ${Math.round(performance.now() - prodStart)}ms)`;
+        prod.data.forEach(p => {
+          const li = document.createElement('li');
+          li.textContent = p.name;
+          document.getElementById('products').appendChild(li);
+        });
+        const taskStart = performance.now();
+        const taskRes = await fetch(`${BASE_URL}/tasks`);
+        const task = await taskRes.json();
+        document.getElementById('tasksInfo').textContent = `Fetched in ${task.time}ms (client ${Math.round(performance.now() - taskStart)}ms)`;
+        task.data.filter(t => t.assigned_to === userId).forEach(t => {
+          const li = document.createElement('li');
+          li.textContent = t.title;
+          document.getElementById('tasks').appendChild(li);
+        });
+      }
+      load();
+    </script>
+  </body>
 </html>

--- a/services/gateway/src/index.js
+++ b/services/gateway/src/index.js
@@ -7,6 +7,16 @@ const PRODUCTS_URL = process.env.PRODUCTS_URL || 'http://products-service:3000';
 
 const app = express();
 
+// Allow the HTML pages to call back into the gateway even when they are
+// opened directly from the filesystem. This sets a permissive CORS header
+// which enables requests from a `file:` origin.
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  next();
+});
+
+// Serve the static front-end assets (index.html, user.html, etc.)
+// so the browser can load them over HTTP instead of the `file:` protocol.
 app.use(express.static(path.join(__dirname, '../public')));
 
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- Allow static pages to request data from the gateway by adding a permissive CORS header
- Detect `file:` origins in `index.html` and `user.html` and route requests through the running gateway

## Testing
- `node services/gateway/src/index.js & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_6897d2044cac833286d0a699d8427874